### PR TITLE
Add path to active developer directory to commandline options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 xcuserdata/
 portable_pecker.zip
 /*.bottle.tar.gz
+.swiftpm

--- a/Sources/Pecker/PeckerCommand.swift
+++ b/Sources/Pecker/PeckerCommand.swift
@@ -18,6 +18,9 @@ struct CommandLineOptions: ParsableArguments {
     /// The configuration file path
     @Option(help: "The path of the configuration file")
     var config: String?
+
+    @Option(help: "The path to Xcode.app")
+    var xcodeAppPath: String?
 }
 
 struct PeckerCommand: ParsableCommand {
@@ -59,7 +62,7 @@ private func createConfiguration(options: CommandLineOptions) throws -> Configur
     }
     let rootPath = AbsolutePath(options.path ?? "", relativeTo: cwd)
     let configPath = try createConfigurationPath(rootPath: rootPath, config: options.config)
-    let configuration = Configuration(projectPath: rootPath, indexStorePath: indexStorePath.asURL.path, configPath: configPath)
+    let configuration = Configuration(projectPath: rootPath, indexStorePath: indexStorePath.asURL.path, xcodeAppPath: options.xcodeAppPath, configPath: configPath)
 
     return configuration
 }

--- a/Sources/Pecker/PeckerCommand.swift
+++ b/Sources/Pecker/PeckerCommand.swift
@@ -19,7 +19,7 @@ struct CommandLineOptions: ParsableArguments {
     @Option(help: "The path of the configuration file")
     var config: String?
 
-    @Option(help: "The path to Xcode.app")
+    @Option(help: "The path to Xcode.app/Contents/Developer (use xcode-select -p)")
     var xcodeAppPath: String?
 }
 

--- a/Sources/PeckerKit/Analyzer.swift
+++ b/Sources/PeckerKit/Analyzer.swift
@@ -16,7 +16,8 @@ public final class Analyzer {
                                               configuration: configuration)
         self.configuration = configuration
         let buildSystem = DatabaseBuildSystem(indexStorePath: configuration.indexStorePath,
-                                              indexDatabasePath: configuration.indexDatabasePath)
+                                              indexDatabasePath: configuration.indexDatabasePath,
+                                              xcodeAppPath: configuration.xcodeAppPath.pathString)
         workSpace = try Workspace(buildSettings: buildSystem)
         workSpace.index?.pollForUnitChangesAndWait()
         sourceKitserver = SourceKitServer(workspace: workSpace)

--- a/Sources/PeckerKit/Analyzer.swift
+++ b/Sources/PeckerKit/Analyzer.swift
@@ -17,7 +17,7 @@ public final class Analyzer {
         self.configuration = configuration
         let buildSystem = DatabaseBuildSystem(indexStorePath: configuration.indexStorePath,
                                               indexDatabasePath: configuration.indexDatabasePath,
-                                              xcodeAppPath: configuration.xcodeAppPath.pathString)
+                                              xcodeAppPath: configuration.activeDeveloperDirectory.pathString)
         workSpace = try Workspace(buildSettings: buildSystem)
         workSpace.index?.pollForUnitChangesAndWait()
         sourceKitserver = SourceKitServer(workspace: workSpace)

--- a/Sources/PeckerKit/Analyzer.swift
+++ b/Sources/PeckerKit/Analyzer.swift
@@ -17,7 +17,7 @@ public final class Analyzer {
         self.configuration = configuration
         let buildSystem = DatabaseBuildSystem(indexStorePath: configuration.indexStorePath,
                                               indexDatabasePath: configuration.indexDatabasePath,
-                                              xcodeAppPath: configuration.activeDeveloperDirectory.pathString)
+                                              activeDeveloperDirectory: configuration.activeDeveloperDirectory.pathString)
         workSpace = try Workspace(buildSettings: buildSystem)
         workSpace.index?.pollForUnitChangesAndWait()
         sourceKitserver = SourceKitServer(workspace: workSpace)

--- a/Sources/PeckerKit/Configuration.swift
+++ b/Sources/PeckerKit/Configuration.swift
@@ -84,7 +84,6 @@ public struct Configuration {
 
         let absoluteXcodeAppPath = createXcodeAppPath(
             pathFromOptions: xcodeAppPath,
-            pathFromConfig: yamlConfiguration?.xcodeAppPath,
             fileSystem: localFileSystem
         )
 
@@ -102,10 +101,8 @@ public struct Configuration {
     }
 }
 
-private func createXcodeAppPath(pathFromOptions: String?, pathFromConfig: String?, fileSystem: FileSystem) -> AbsolutePath {
+private func createXcodeAppPath(pathFromOptions: String?, fileSystem: FileSystem) -> AbsolutePath {
     if let absolutePath = absolutePathIfExists(path: pathFromOptions, fileSystem: localFileSystem) {
-        return absolutePath
-    } else if let absolutePath = absolutePathIfExists(path: pathFromConfig, fileSystem: localFileSystem) {
         return absolutePath
     } else {
         return AbsolutePath("/Applications/Xcode.app/Contents/Developer")

--- a/Sources/PeckerKit/Configuration.swift
+++ b/Sources/PeckerKit/Configuration.swift
@@ -108,7 +108,7 @@ private func createXcodeAppPath(pathFromOptions: String?, pathFromConfig: String
     } else if let absolutePath = absolutePathIfExists(path: pathFromConfig, fileSystem: localFileSystem) {
         return absolutePath
     } else {
-        return AbsolutePath("/Applications/Xcode.app")
+        return AbsolutePath("/Applications/Xcode.app/Contents/Developer")
     }
 }
 

--- a/Sources/PeckerKit/Configuration.swift
+++ b/Sources/PeckerKit/Configuration.swift
@@ -30,7 +30,9 @@ public struct Configuration {
     
     /// The project index database path
     public var indexDatabasePath: String
-    
+
+    public var xcodeAppPath: AbsolutePath
+
     internal init(projectPath: AbsolutePath,
                   indexStorePath: String,
                   rules: [Rule],
@@ -40,7 +42,8 @@ public struct Configuration {
                   excludedGroupName: [String],
                   blacklistFiles: [String],
                   blacklistSymbols: [String],
-                  outputFile: AbsolutePath) {
+                  outputFile: AbsolutePath,
+                  xcodeAppPath: AbsolutePath) {
         self.projectPath = projectPath
         self.indexStorePath = indexStorePath
         self.indexDatabasePath = NSTemporaryDirectory() + "index_\(getpid())"
@@ -52,6 +55,7 @@ public struct Configuration {
         self.blacklistFiles = blacklistFiles
         self.blacklistSymbols = blacklistSymbols
         self.outputFile = outputFile
+        self.xcodeAppPath = xcodeAppPath
     }
     
     public init(projectPath: AbsolutePath, indexStorePath: String = "", configPath: AbsolutePath) {
@@ -77,6 +81,8 @@ public struct Configuration {
         let excluded = (yamlConfiguration?.excluded ?? []).map {
             return AbsolutePath($0, relativeTo: projectPath)
         }.filter { localFileSystem.exists($0) }
+
+        let xcodeAppPath = createXcodeAppPath(path: yamlConfiguration?.xcodeAppPath, fileSystem: localFileSystem) ?? AbsolutePath("/Applications/Xcode.app")
         
         self.init(projectPath: projectPath,
                   indexStorePath: indexStorePath,
@@ -87,8 +93,16 @@ public struct Configuration {
                   excludedGroupName: yamlConfiguration?.excludedGroupName ?? [],
                   blacklistFiles: yamlConfiguration?.blacklistFiles ?? [],
                   blacklistSymbols: yamlConfiguration?.blacklistSymbols ?? [],
-                  outputFile: outputFilePath)
+                  outputFile: outputFilePath,
+                  xcodeAppPath: xcodeAppPath)
     }
+}
+
+private func createXcodeAppPath(path: String?, fileSystem: FileSystem) -> AbsolutePath? {
+    guard let path = path else { return nil }
+    let absolutePath = AbsolutePath(path)
+    guard fileSystem.exists(absolutePath) else { return nil }
+    return absolutePath
 }
 
 private func createOutputFilePath(projectPath: AbsolutePath, outputFile: String?) -> AbsolutePath {

--- a/Sources/PeckerKit/Models/YamlConfiguration.swift
+++ b/Sources/PeckerKit/Models/YamlConfiguration.swift
@@ -31,7 +31,10 @@ public struct YamlConfiguration: Decodable {
     
     /// The path of the output  json file
     public let outputFile: String?
-    
+
+    // The path to Xcode.app
+    public let xcodeAppPath: String?
+
     enum CodingKeys: String, CodingKey {
         case disabledRules = "disabled_rules"
         case reporter
@@ -43,6 +46,7 @@ public struct YamlConfiguration: Decodable {
         case blacklistSymbols = "blacklist_symbols"
         case blacklistSuperClass = "blacklist_superclass"
         case outputFile = "output_file"
+        case xcodeAppPath = "xcode_app_path"
     }
     
     public init(from decoder: Decoder) throws {
@@ -57,6 +61,7 @@ public struct YamlConfiguration: Decodable {
         self.blacklistSymbols = try container.decodeIfPresent([String].self, forKey: .blacklistSymbols)
         self.blacklistSuperClass = try container.decodeIfPresent([String].self, forKey: .blacklistSuperClass)
         self.outputFile = try container.decodeIfPresent(String.self, forKey: .outputFile)
+        self.xcodeAppPath = try container.decodeIfPresent(String.self, forKey: .xcodeAppPath)
     }
 }
 

--- a/Sources/PeckerKit/Models/YamlConfiguration.swift
+++ b/Sources/PeckerKit/Models/YamlConfiguration.swift
@@ -32,9 +32,6 @@ public struct YamlConfiguration: Decodable {
     /// The path of the output  json file
     public let outputFile: String?
 
-    // The path to Xcode.app
-    public let xcodeAppPath: String?
-
     enum CodingKeys: String, CodingKey {
         case disabledRules = "disabled_rules"
         case reporter
@@ -46,7 +43,6 @@ public struct YamlConfiguration: Decodable {
         case blacklistSymbols = "blacklist_symbols"
         case blacklistSuperClass = "blacklist_superclass"
         case outputFile = "output_file"
-        case xcodeAppPath = "xcode_app_path"
     }
     
     public init(from decoder: Decoder) throws {
@@ -61,7 +57,6 @@ public struct YamlConfiguration: Decodable {
         self.blacklistSymbols = try container.decodeIfPresent([String].self, forKey: .blacklistSymbols)
         self.blacklistSuperClass = try container.decodeIfPresent([String].self, forKey: .blacklistSuperClass)
         self.outputFile = try container.decodeIfPresent(String.self, forKey: .outputFile)
-        self.xcodeAppPath = try container.decodeIfPresent(String.self, forKey: .xcodeAppPath)
     }
 }
 

--- a/Sources/PeckerKit/SourceKitServer/DatabaseBuildSystem.swift
+++ b/Sources/PeckerKit/SourceKitServer/DatabaseBuildSystem.swift
@@ -7,9 +7,12 @@ struct DatabaseBuildSystem {
     
     /// The path to put the index database, if any.
     var indexDatabasePath: String?
-    
-    init(indexStorePath: String?, indexDatabasePath: String?) {
+
+    let xcodeAppPath: String
+
+    init(indexStorePath: String?, indexDatabasePath: String?, xcodeAppPath: String) {
         self.indexStorePath = indexStorePath
         self.indexDatabasePath = indexDatabasePath
+        self.xcodeAppPath = xcodeAppPath
     }
 }

--- a/Sources/PeckerKit/SourceKitServer/DatabaseBuildSystem.swift
+++ b/Sources/PeckerKit/SourceKitServer/DatabaseBuildSystem.swift
@@ -8,11 +8,11 @@ struct DatabaseBuildSystem {
     /// The path to put the index database, if any.
     var indexDatabasePath: String?
 
-    let xcodeAppPath: String
+    let activeDeveloperDirectory: String
 
-    init(indexStorePath: String?, indexDatabasePath: String?, xcodeAppPath: String) {
+    init(indexStorePath: String?, indexDatabasePath: String?, activeDeveloperDirectory: String) {
         self.indexStorePath = indexStorePath
         self.indexDatabasePath = indexDatabasePath
-        self.xcodeAppPath = xcodeAppPath
+        self.activeDeveloperDirectory = activeDeveloperDirectory
     }
 }

--- a/Sources/PeckerKit/SourceKitServer/Workspace.swift
+++ b/Sources/PeckerKit/SourceKitServer/Workspace.swift
@@ -13,7 +13,7 @@ class Workspace {
     init(buildSettings: DatabaseBuildSystem) throws {
         self.buildSettings = buildSettings
 
-        let libIndexStoreDylibPath = buildSettings.xcodeAppPath.appending("/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib")
+        let libIndexStoreDylibPath = buildSettings.activeDeveloperDirectory.appending("/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib")
 
         if let storePath = buildSettings.indexStorePath,
             let dbPath = buildSettings.indexDatabasePath {

--- a/Sources/PeckerKit/SourceKitServer/Workspace.swift
+++ b/Sources/PeckerKit/SourceKitServer/Workspace.swift
@@ -3,8 +3,6 @@ import IndexStoreDB
 
 class Workspace {
     
-    static let libIndexStore = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib"
-        
     /// Build setup
     let buildSettings: DatabaseBuildSystem
 
@@ -14,11 +12,13 @@ class Workspace {
     /// The directory containing the original, unmodified project.
     init(buildSettings: DatabaseBuildSystem) throws {
         self.buildSettings = buildSettings
-        
+
+        let libIndexStoreDylibPath = buildSettings.xcodeAppPath.appending("/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib")
+
         if let storePath = buildSettings.indexStorePath,
             let dbPath = buildSettings.indexDatabasePath {
             do {
-                let lib = try IndexStoreLibrary(dylibPath: Workspace.libIndexStore)
+                let lib = try IndexStoreLibrary(dylibPath: libIndexStoreDylibPath)
                 self.index = try IndexStoreDB(
                     storePath: URL(fileURLWithPath: storePath).path,
                     databasePath: NSTemporaryDirectory() + "index_\(getpid())",

--- a/Sources/PeckerKit/SourceKitServer/Workspace.swift
+++ b/Sources/PeckerKit/SourceKitServer/Workspace.swift
@@ -13,7 +13,7 @@ class Workspace {
     init(buildSettings: DatabaseBuildSystem) throws {
         self.buildSettings = buildSettings
 
-        let libIndexStoreDylibPath = buildSettings.xcodeAppPath.appending("/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib")
+        let libIndexStoreDylibPath = buildSettings.xcodeAppPath.appending("/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib")
 
         if let storePath = buildSettings.indexStorePath,
             let dbPath = buildSettings.indexDatabasePath {


### PR DESCRIPTION
Currently the path to `libIndexStore` is hard-coded to `/Applications/Xcode.app/...`. Working with different versions of Xcode requires selecting the Xcode to use. This PR adds an option to the command line interface.

```bash
pecker [...] --active-developer-directory "/Applications/Xcode-13.3.app/Contents/Developer" [...]

pecker [...] --active-developer-directory "$(xcode-select -p)" [...]
```

```bash
▶ .build/debug/pecker --help
OVERVIEW: Detect unused Swift and Objective-C code

USAGE: Pecker [--path <path>] [--index-store-path <index-store-path>] [--config <config>] [--active-developer-directory <active-developer-directory>]

OPTIONS:
  --path <path>           Path of the project to detect
  -i, --index-store-path <index-store-path>
                          Specify project index path [default:
                          ~/Library/Developer/Xcode/DerivedData]
  --config <config>       The path of the configuration file
  --active-developer-directory <active-developer-directory>
                          The path of the active developer directory; Using 'xcode-select
                          -p' is recommended (default:
                          /Applications/Xcode.app/Contents/Developer)
  --version               Show the version.
  -h, --help              Show help information.
```
